### PR TITLE
corrected handling of gurobi license file in container

### DIFF
--- a/nf/bin/mtg/merge_hmm.sh
+++ b/nf/bin/mtg/merge_hmm.sh
@@ -4,8 +4,7 @@ output_file="$2"
 
 echo -e "bin_id\tcontig_id\tko_term" > $output_file
 
-ls hmmout_*/*.hmmout \
-  | parallel -j $threads --bar --no-notice '
+find hmmout_*/ -name "*.hmmout" -print0 | parallel -0 -j $threads --bar --no-notice '
       f={}
 
       # Skip file if it has no non-comment lines

--- a/nf/modules/gem_recon/main.nf
+++ b/nf/modules/gem_recon/main.nf
@@ -30,7 +30,7 @@ process CARVE {
 
     publishDir "${params.outdir}/reconstructions", mode: 'copy', overwrite: true
     container "hariszaf/carveme:1.6.6"
-    containerOptions = gurobiBind
+    containerOptions gurobiBind
 
     input:
         path in_chunk

--- a/nf/modules/kofam/main.nf
+++ b/nf/modules/kofam/main.nf
@@ -52,7 +52,7 @@ process MERGE_HMMOUT {
     script:
         """
         merge_hmm.sh ${params.threads} ko_merged.txt
-        tar -zcvf hmmout.tar.gz hmmout_*/*.hmmout
+        find hmmout_*/ -name "*.hmmout" -type f -print | tar -zcvf hmmout.tar.gz -T -
         """
 }
 


### PR DESCRIPTION
- variable in containerOptions was not set correctly (no '=' needed)
- caused that gurobi was not working with carveme in microbetag